### PR TITLE
Fix wording + misc whitespace fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <h1 align="center">ksylint</h1>
 
-<p align="center">Check kaitai .ksy files for errors and style flaws.</p>
+<p align="center">Check Kaitai Struct .ksy files for errors and style flaws.</p>
 
-<p  align="center">
+<p align="center">
  <a href="https://dev.azure.com/cugu/dfir/_build?definitionId=5&_a=summary"><img src="https://img.shields.io/azure-devops/build/cugu/dfir/5" alt="build" /></a>
  <a href="https://dev.azure.com/cugu/dfir/_build?definitionId=5&_a=summary"><img src="https://img.shields.io/azure-devops/coverage/cugu/dfir/5" alt="coverage" /></a>
 </p>


### PR DESCRIPTION
In general, it's preferred to avoid using bare "kaitai" wording to reference "kaitai struct" as a project, as "kaitai" is the name of the team that produces/publishes different projects — although https://kaitai.io/ is currently dedicated only to one.

Please consider changing the wording to maintain that naming practice?