### PR TITLE
Add shebang to main executable file

### DIFF
--- a/ksylint/lint.py
+++ b/ksylint/lint.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from jsonschema import Draft7Validator
 from yamllint import linter, config
 import argparse


### PR DESCRIPTION
This allows running Python script without "python ksylint.py" in UNIX-like environments.